### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 adldap2 (10.4.1-3) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 12 Oct 2022 14:03:26 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ adldap2 (10.4.1-3) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse.
   * Update standards version to 4.6.1, no changes needed.
+  * Set upstream metadata fields: Repository, Security-Contact.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 12 Oct 2022 14:03:26 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+adldap2 (10.4.1-3) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 12 Oct 2022 14:03:26 -0000
+
 adldap2 (10.4.1-2) unstable; urgency=medium
 
   * Increasing version number (Upload to testing).

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ adldap2 (10.4.1-3) UNRELEASED; urgency=medium
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse.
   * Update standards version to 4.6.1, no changes needed.
   * Set upstream metadata fields: Repository, Security-Contact.
+  * Update standards version to 4.6.2, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 12 Oct 2022 14:03:26 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
  phpab,
  pkg-php-tools,
 Rules-Requires-Root: no
-Standards-Version: 4.6.1
+Standards-Version: 4.6.2
 Homepage: https://adldap2.github.io/Adldap2/
 Vcs-Browser: https://github.com/sunflowerbofh/Adldap2
 Vcs-Git: https://github.com/sunflowerbofh/Adldap2.git

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
  phpab,
  pkg-php-tools,
 Rules-Requires-Root: no
-Standards-Version: 4.6.0
+Standards-Version: 4.6.1
 Homepage: https://adldap2.github.io/Adldap2/
 Vcs-Browser: https://github.com/sunflowerbofh/Adldap2
 Vcs-Git: https://github.com/sunflowerbofh/Adldap2.git

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+---
+Bug-Database: https://github.com/Adldap2/Adldap2/issues
+Bug-Submit: https://github.com/Adldap2/Adldap2/issues/new
+Repository-Browse: https://github.com/Adldap2/Adldap2

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,4 +1,6 @@
 ---
 Bug-Database: https://github.com/Adldap2/Adldap2/issues
 Bug-Submit: https://github.com/Adldap2/Adldap2/issues/new
+Repository: https://github.com/Adldap2/Adldap2.git
 Repository-Browse: https://github.com/Adldap2/Adldap2
+Security-Contact: https://github.com/Adldap2/Adldap2/tree/HEAD/SECURITY.md


### PR DESCRIPTION
Fix some issues reported by lintian

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking))
* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))
* Set upstream metadata fields: Repository, Security-Contact. ([upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

These changes have no impact on the [binary debdiff](https://janitor.debian.net/api/run/70c5ce84-fd40-46cc-815b-dd608e18970d/debdiff?filter_boring=1).

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/70c5ce84-fd40-46cc-815b-dd608e18970d/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/70c5ce84-fd40-46cc-815b-dd608e18970d/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/run/70c5ce84-fd40-46cc-815b-dd608e18970d.